### PR TITLE
installed_app_id parameter in AppWebsocket::connect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod admin_websocket;
 mod app_websocket;
 mod error;
+mod types;
+pub use types::*;
 
 pub use admin_websocket::AdminWebsocket;
 pub use app_websocket::AppWebsocket;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,57 @@
+
+use holochain_types::prelude::{InstalledAppId, CloneCellId, EnableCloneCellPayload, DisableCloneCellPayload, CreateCloneCellPayload};
+use holochain_zome_types::{RoleName, DnaModifiersOpt, YamlProperties, MembraneProof};
+
+
+pub struct AppEnableCloneCellPayload {
+  pub clone_cell_id: CloneCellId
+}
+
+impl AppEnableCloneCellPayload {
+  pub fn into_enable_clone_cell_payload(self, app_id: InstalledAppId) -> EnableCloneCellPayload {
+      EnableCloneCellPayload {
+        app_id,
+        clone_cell_id: self.clone_cell_id,
+      }
+  }
+}
+
+pub struct AppDisableCloneCellPayload {
+  pub clone_cell_id: CloneCellId
+}
+
+impl AppDisableCloneCellPayload {
+  pub fn into_disable_clone_cell_payload(self, app_id: InstalledAppId) -> DisableCloneCellPayload {
+      DisableCloneCellPayload {
+        app_id,
+        clone_cell_id: self.clone_cell_id
+      }
+  }
+}
+
+pub struct AppCreateCloneCellPayload {
+    /// The DNA's role name to clone
+    pub role_name: RoleName,
+    /// Modifiers to set for the new cell.
+    /// At least one of the modifiers must be set to obtain a distinct hash for
+    /// the clone cell's DNA.
+    pub modifiers: DnaModifiersOpt<YamlProperties>,
+    /// Optionally set a proof of membership for the clone cell
+    pub membrane_proof: Option<MembraneProof>,
+    /// Optionally a name for the DNA clone
+    pub name: Option<String>,
+}
+
+impl AppCreateCloneCellPayload {
+  pub fn into_create_clone_cell_payload(self, app_id: InstalledAppId) -> CreateCloneCellPayload {
+      CreateCloneCellPayload {
+        app_id,
+        role_name: self.role_name,
+        modifiers: self.modifiers,
+        membrane_proof: self.membrane_proof,
+        name: self.name,
+      }
+  }
+}
+
+

--- a/tests/admin.rs
+++ b/tests/admin.rs
@@ -40,10 +40,10 @@ async fn signed_zome_call() {
         .unwrap();
     admin_ws.enable_app(app_id.clone()).await.unwrap();
     let app_ws_port = admin_ws.attach_app_interface(30000).await.unwrap();
-    let mut app_ws = AppWebsocket::connect(format!("ws://localhost:{}", app_ws_port))
+    let mut app_ws = AppWebsocket::connect(format!("ws://localhost:{}", app_ws_port), app_id)
         .await
         .unwrap();
-    let installed_app = app_ws.app_info(app_id).await.unwrap().unwrap();
+    let installed_app = app_ws.app_info().await.unwrap().unwrap();
 
     let cells = installed_app.cell_info.into_values().next().unwrap();
     let cell_id = match cells[0].clone() {

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -33,7 +33,7 @@ async fn network_info() {
     admin_ws.enable_app(app_id.clone()).await.unwrap();
     let app_ws_port = 33000;
     admin_ws.attach_app_interface(app_ws_port).await.unwrap();
-    let mut app_ws = AppWebsocket::connect(format!("ws://localhost:{}", app_ws_port))
+    let mut app_ws = AppWebsocket::connect(format!("ws://localhost:{}", app_ws_port), app_id)
         .await
         .unwrap();
 


### PR DESCRIPTION
AppWebsocket now takes a second parameter `installed_app_id: String` to match the api used in holochain-client-js. 

Function calls from an initialized AppWebsocket no longer need to be passed the app id.

This is a breaking change.