### PR TITLE
feat: pass a custom WebsocketConfig to connect for overriding default timeout

### DIFF
--- a/src/admin_websocket.rs
+++ b/src/admin_websocket.rs
@@ -58,6 +58,11 @@ impl AdminWebsocket {
     /// As string `"localhost:30000"`
     /// As tuple `([127.0.0.1], 30000)`
     pub async fn connect(socket_addr: impl ToSocketAddrs) -> Result<Self> {
+        Self::connect_with_config(socket_addr, Arc::new(WebsocketConfig::CLIENT_DEFAULT))
+    }
+
+    /// Connect to a Conductor API AdminWebsocket with a custom WebsocketConfig.
+    pub async fn connect_with_config(socket_addr: impl ToSocketAddrs, config: Arc<WebsocketConfig>) -> Result<Self> {
         let addr = socket_addr
             .to_socket_addrs()?
             .next()

--- a/src/admin_websocket.rs
+++ b/src/admin_websocket.rs
@@ -58,7 +58,7 @@ impl AdminWebsocket {
     /// As string `"localhost:30000"`
     /// As tuple `([127.0.0.1], 30000)`
     pub async fn connect(socket_addr: impl ToSocketAddrs) -> Result<Self> {
-        Self::connect_with_config(socket_addr, Arc::new(WebsocketConfig::CLIENT_DEFAULT))
+        Self::connect_with_config(socket_addr, Arc::new(WebsocketConfig::CLIENT_DEFAULT)).await
     }
 
     /// Connect to a Conductor API AdminWebsocket with a custom WebsocketConfig.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use holochain_types::{
     app::{InstallAppPayload, InstalledAppId},
     dna::AgentPubKey,
 };
+pub use holochain_websocket::WebsocketConfig;
 pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]
 pub use signing::lair_signing::LairAgentSigner;


### PR DESCRIPTION
Add a new function to AdminWebsocket: connect_with_config to pass in a custom WebSocket config with a different default timeout.