### PR TITLE
Improve Nix development experience

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Types and bindings to connect easily to a running Holochain conductor from Rust.
 
 ``` bash
 ./build-fixture.sh
-cargo test
+cargo test --release
 ```
 
 ## Contribute

--- a/build-fixture.sh
+++ b/build-fixture.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CARGO_HOME=./fixture/zomes/foo/.cargo cargo build -p test_wasm_foo --release --target wasm32-unknown-unknown --target-dir ./fixture/zomes/foo/target

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             ] ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
               # needed to build Holochain on macos
               pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+              pkgs.bzip2
             ]);
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
               inputs'.holonix.packages.lair-keystore
               inputs'.holonix.packages.rust
               pkgs.go
+              pkgs.perl
             ] ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
               # needed to build Holochain on macos
               pkgs.darwin.apple_sdk.frameworks.SystemConfiguration


### PR DESCRIPTION
Some small changes to improve Nix support.

* Add direnv support to use the nix `devShell`.
* Change `build-fixture.sh` shebang path to use `env`.
* Add perl package to the `devShell` as it is a requirement to build openssl.
* Updated the README.md as running `cargo test` without the `--release` flag fails.