### PR TITLE
feat: update holochain deps to dev.7 and use new zome signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,25 +95,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aitia"
-version = "0.4.0-dev.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6894dec71e83f4223465d784cf9026fa0eba3b73227ae1dd9623f22d17426f"
-dependencies = [
- "anyhow",
- "derive_more",
- "parking_lot 0.12.3",
- "petgraph",
- "regex",
- "serde",
- "serde_json",
- "tracing",
- "tracing-core",
- "tracing-serde",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,12 +1686,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2155,7 +2136,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2174,7 +2155,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2242,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "hc_deepkey_sdk"
-version = "0.8.0-dev.0"
+version = "0.8.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bb90d51d03d3a97ac1de710effac217a7a0949185f65f6720eaf698fc28966"
+checksum = "c792eda892a4bf78cb6673d6a2ac8925e028cee469d0a6f360abc5af9089b9e6"
 dependencies = [
  "arbitrary",
  "hc_deepkey_types",
@@ -2255,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "hc_deepkey_types"
-version = "0.9.0-dev.0"
+version = "0.9.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0015139c3670a8784f906f851cc71763b69dc6eb62c2d02e89108d25de02172"
+checksum = "9241002193afbfbd3db9e40e6dfe079c67b26fbe353f82770986a905250d7bba"
 dependencies = [
  "arbitrary",
  "hdi",
@@ -2294,32 +2275,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hc_sleuth"
-version = "0.5.0-dev.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a90a2e01a05403c66668e50b8d17ecd393f0ece9466dbf244d0c0e8e852df44"
-dependencies = [
- "aitia",
- "anyhow",
- "derive_more",
- "holochain_trace",
- "holochain_types",
- "kitsune_p2p",
- "once_cell",
- "parking_lot 0.12.3",
- "petgraph",
- "regex",
- "serde",
- "structopt",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "hdi"
-version = "0.6.0-dev.0"
+version = "0.6.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af78e9b24538f22e7b10e9bd933d0ea3f77618a77b1011333aac6947b26b3"
+checksum = "fd2b81d1ca8036deba19b4d55ece09def176eeb062a49391369ccb424223c917"
 dependencies = [
  "getrandom 0.2.15",
  "hdk_derive",
@@ -2335,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173945f0aa24fb566921a6b36c9c148217f35e00dd185c98f793e9b1580104d1"
+checksum = "bdca5784af969790afdbc1c6bf30ec677ddfde2e3961bcea07fe73d7ecd15c39"
 dependencies = [
  "getrandom 0.2.15",
  "hdi",
@@ -2355,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0f3a32de97f3729ef6d1e47a9f8d589b46820dcdd356581c39fb44820ace1c"
+checksum = "3477a3b1fa6e302d14144397a7cf669e7806e6b116e6f432411d232d8c3c243d"
 dependencies = [
  "darling 0.14.4",
  "heck 0.5.0",
@@ -2452,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5dc048798bbb36c18131b96200a8fc506f11516c9ba3db2b9f1ad0cca3d6ea4"
+checksum = "e9ef5f1b831a64ab1e1d2a2d6c76b8140c59660cd9b6c745eaf0c4b0d03b9257"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -2473,23 +2432,22 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_bytes",
+ "sha2",
  "thiserror 1.0.64",
 ]
 
 [[package]]
 name = "holochain"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1d58365de0252f17d43a06f92e91ca95ae7e46639896e4e5e7956eaa3c5b29"
+checksum = "cd9e14e0a797f47e68f4cd54ebac882fb8caa7b313eb336ce886159056a4cb6b"
 dependencies = [
- "aitia",
  "anyhow",
  "arbitrary",
  "async-once-cell",
  "async-trait",
  "backtrace",
  "base64 0.22.1",
- "bytes",
  "cfg-if 1.0.0",
  "chrono",
  "contrafact",
@@ -2503,7 +2461,6 @@ dependencies = [
  "getrandom 0.2.15",
  "ghost_actor",
  "hc_deepkey_sdk",
- "hc_sleuth",
  "hdk",
  "holo_hash",
  "holochain_cascade",
@@ -2529,6 +2486,7 @@ dependencies = [
  "holochain_zome_types",
  "hostname",
  "human-panic",
+ "indexmap 2.6.0",
  "itertools 0.12.1",
  "kitsune_p2p",
  "kitsune_p2p_bin_data",
@@ -2549,7 +2507,6 @@ dependencies = [
  "rand 0.8.5",
  "rand-utf8",
  "rand_chacha 0.3.1",
- "reqwest 0.12.9",
  "rusqlite",
  "sbd-server",
  "sd-notify",
@@ -2583,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86d258f9af2c12131925618dd02d9d14b20a989025ea9e4e7102a101b35182b"
+checksum = "08c612e8bbabaf084748195e06bff68fedc9f879edfdda1689827bce1f170d03"
 dependencies = [
  "async-trait",
  "fixt",
@@ -2611,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_chc"
-version = "0.2.0-dev.0"
+version = "0.2.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6baf65c0bc91d98fbff5d6dcf684c2beb7f5163b0ef2dfb0285febeb33038939"
+checksum = "bbf3c6f2fb23859c1174fcdc09d871754d1365f6a204c91f9d302566047b5bfb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2662,10 +2619,11 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1f63f327a8dd161f6593bc56cabbeb85a3600aa78646a498c339cabaa84b7c"
+checksum = "721649eecde51d31d6602d3a7f6cdfd10cabff55145a76f487d31a7addc668d2"
 dependencies = [
+ "cfg-if 1.0.0",
  "derive_more",
  "holo_hash",
  "holochain_keystore",
@@ -2673,6 +2631,7 @@ dependencies = [
  "holochain_state_types",
  "holochain_types",
  "holochain_zome_types",
+ "indexmap 2.6.0",
  "kitsune_p2p_bin_data",
  "kitsune_p2p_types",
  "nanoid",
@@ -2686,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_services"
-version = "0.4.0-dev.0"
+version = "0.4.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc39b1aa57b7903fa57305299b64f85ec9c9e13c400e16c7a8cb9ed71d1e7372"
+checksum = "f46067caf2d694d9d9cb217cecac796d3dbcb60d4692941daf31a6adcb20fcc5"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2717,9 +2676,9 @@ checksum = "be0aa773b74c40ef5e4e02f414d8cbfc4e92520a93511055a3fbccc12d2dd045"
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1a86905cce3b389c6d3424aae96045f62d72cf03ef863603176c883ff2e675"
+checksum = "8835be40ef1c0dffbfa111991611169a886506c48d45c91dce9523eae7639a14"
 dependencies = [
  "arbitrary",
  "derive_builder 0.20.2",
@@ -2739,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885e523fae6f3c281fedcfe15bd4e23f5b994fe4c58462036a79042c42c3b20e"
+checksum = "d36f5c77333a5afaacc3b630b10b7b9757b1a515925b2f0a98449e8d242a7e48"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -2790,17 +2749,15 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e7fe51b6579169224766a183bda3076e74b478d3b297bf34af4959ddd99779"
+checksum = "70833ee26db1614f6aaeeab2a75d4833ef6fc042fff4536ed116b562a8ac586b"
 dependencies = [
- "aitia",
  "async-trait",
  "derive_more",
  "fixt",
  "futures",
  "ghost_actor",
- "hc_sleuth",
  "holo_hash",
  "holochain_chc",
  "holochain_keystore",
@@ -2862,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5de2f88ed0cd8ba58f248f34a2b359849f667364bc8f376c7cea7fb9a21b4f8"
+checksum = "eae44976a186d612094ad2ecbb9e449c22f02e8c732bb6860e2a482059797940"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2907,11 +2864,10 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fe0824294a8eaf1116781bde81bc5844d631b48cf0cb0d87114854d74e3a3d"
+checksum = "9d5fca3bedcf1b02762371e20bc430bd3774e67ddf5b804cd525ccc87748f1e1"
 dependencies = [
- "aitia",
  "async-recursion",
  "base64 0.22.1",
  "chrono",
@@ -2919,7 +2875,6 @@ dependencies = [
  "cron",
  "derive_more",
  "fallible-iterator 0.3.0",
- "hc_sleuth",
  "holo_hash",
  "holochain_chc",
  "holochain_keystore",
@@ -2931,6 +2886,7 @@ dependencies = [
  "holochain_types",
  "holochain_zome_types",
  "kitsune_p2p",
+ "maplit",
  "nanoid",
  "one_err",
  "parking_lot 0.12.3",
@@ -2945,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d60f6c7fec5bb82b7cf377a9418c33149951d33d64edde9e8782d93c4c9476"
+checksum = "93937b0ae3bb6ac53216ae8a59c8212442591875720d9c8310299b9fbcaf913b"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -2956,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77800dc8bcc5621afde82415abd0d8b8915c7de7d8b8b91b15b464313164de8b"
+checksum = "e6ccfdf6c2919ff3ee71b4a4772609d8254c4f193ee988f006ab8d061b34acec"
 dependencies = [
  "hdk",
  "serde",
@@ -2984,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d2a87d1c79cca83a31ca2478c67f3a1a4f1d1ef63d1b617753c222a4a97892"
+checksum = "dabc1aeb326eea615e9cd38b10c70105ecc871704cee3cd448883e54bbb3f75b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3011,6 +2967,7 @@ dependencies = [
  "holochain_trace",
  "holochain_util",
  "holochain_zome_types",
+ "indexmap 2.6.0",
  "isotest",
  "itertools 0.12.1",
  "kitsune_p2p_dht",
@@ -3058,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9262117cbb4c0ad9d34fbf5c7203919db66cb1ebc4d96386b441f476011416be"
+checksum = "8559e377548555ac498c27275006a37bce3a3f6c020fe64245031da77042c765"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -3119,9 +3076,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648b01112625b18a6b4699422341ce893f1ead770ce67fbf80bbac3dfa3cacad"
+checksum = "46691e0acd7089fdcca00d7f7bff81db556a583f1006e9c08d374fefc79111a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -3137,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be88023b8fc223869aa14387f27c41e6846dbf7f659a42a1607a804b3cb8bfc"
+checksum = "53206125cfcc90d3aeca074bd97f715e64909443b5bda6b52569e0a82216e19c"
 dependencies = [
  "arbitrary",
  "contrafact",
@@ -3577,12 +3534,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -3598,7 +3555,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap 6.1.0",
  "env_logger",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "is-terminal",
  "itoa",
  "log",
@@ -3860,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e5863cb2e4c7e9dd974789d5c71c00c30527a5d117d38e99b718e3ada74550"
+checksum = "3914718e4f4283f724b24603e80839d7c34d412f37ab2dc5778f6bf2cd4d1d53"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -3880,7 +3837,6 @@ dependencies = [
  "kitsune_p2p_bootstrap_client",
  "kitsune_p2p_fetch",
  "kitsune_p2p_mdns",
- "kitsune_p2p_proxy",
  "kitsune_p2p_timestamp",
  "kitsune_p2p_types",
  "maplit",
@@ -3892,6 +3848,7 @@ dependencies = [
  "opentelemetry_api",
  "parking_lot 0.12.3",
  "rand 0.8.5",
+ "sbd-server",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3900,14 +3857,15 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tx5",
+ "tx5-signal-srv",
  "url2",
 ]
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b4a76c0998aaa559a3018961e26421a660622a1826d26ac8890f99b4f50195"
+checksum = "cdad6312254025109091085d36d39b33fda3bdc76f8e09fb864a857213d8682d"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -3924,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727bb87a87bfe40cb1b10bc0bfc470bf973792f6778542f3e6b88020489a2db2"
+checksum = "21ba383226a21b793adee599c2ff27e5fce2eb4c3a1779dd02b3611fc24b5009"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -3935,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap"
-version = "0.4.0-dev.0"
+version = "0.4.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5fdc113418aa5379ec44a2643e3bc2fa9ca6b297ccad991e9e769d8db2c6f51"
+checksum = "1ddb92b53dcaf35c5ab0d82cdf50acbe751a648dfea2d22e52dd3226673eb43a"
 dependencies = [
  "clap 4.5.21",
  "futures",
@@ -3955,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e230cc43b0881d0e6c84a9820f7a50580437928dbacbbaaee8216485e034fc87"
+checksum = "b94f07ef9bfcebde6a1692957f3c18c040f4220955ab60ef8a9ce7bc4226288d"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_bootstrap",
@@ -3970,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455fa7777df7e52cbdff53b408fa090cd9040cfecdbfff7f0b93dae528bfb78f"
+checksum = "f30d62708218f8afc1c050ffc755ee556234cfe920869f74d9d75cf64cbfe6cc"
 dependencies = [
  "arbitrary",
  "colored",
@@ -3994,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e78ac45360e0652ab126402ce86f48daeda46cda3bd6b85355c2767f7752e0"
+checksum = "a9491afd841f355b448c20e6792f3e8c36ead8f7bd0c26ca7ee468718076266b"
 dependencies = [
  "arbitrary",
  "derive_more",
@@ -4012,15 +3970,16 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e126c470657d7dcc59fe64b5f3d74840e992344fec4d3ff329092a1a8218c84a"
+checksum = "2337626d2df7b58aff5e02d9d801151933b748027669b92043fab61dc83eb7e7"
 dependencies = [
  "backon",
  "derive_more",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "kitsune_p2p_timestamp",
  "kitsune_p2p_types",
+ "rusqlite",
  "serde",
  "tokio",
  "tracing",
@@ -4041,22 +4000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kitsune_p2p_proxy"
-version = "0.5.0-dev.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ef5c8e3fe3b89891f5e04fbe7a3252024d1f2d6564e48c89606fce8ae5e5de"
-dependencies = [
- "base64 0.22.1",
- "derive_more",
- "futures",
- "holochain_trace",
- "kitsune_p2p_types",
- "serde",
- "serde_bytes",
- "tokio",
-]
-
-[[package]]
 name = "kitsune_p2p_timestamp"
 version = "0.5.0-dev.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4074,9 +4017,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62744cd87ac895eaa713ae32e1f7c775fd7bf63b96738f874ca92a947cec6cce"
+checksum = "23ddf3e3d9110d1a1567033c75a592e667cb8813cb095ed23db657489d805327"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -4173,9 +4116,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libflate"
@@ -5045,7 +4988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "quickcheck",
 ]
 
@@ -5231,6 +5174,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.3",
+ "protobuf",
+ "thiserror 1.0.64",
+]
+
+[[package]]
 name = "proptest"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,6 +5229,12 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -5959,9 +5923,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -6111,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-client"
-version = "0.0.6-alpha"
+version = "0.0.8-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f0b06ca514d8666ff371c63a5913e3f1740312c13768f301d0e5578a03c7e2"
+checksum = "7af51493c7b0233ad96af18edaace4190d19a1b3b7c231f61b4a0c7f9bf13ef7"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6130,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-e2e-crypto-client"
-version = "0.0.6-alpha"
+version = "0.0.8-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d257a338fa0fca74d013b69a9e49f3683a4766bcadd4fe583779783bec48dede"
+checksum = "6213eb9eaa35d0e8e57172e5367f2a9c3cfd6011db268143a14c6324ea15c13b"
 dependencies = [
  "sbd-client",
  "sodoken 0.0.901-alpha",
@@ -6142,9 +6106,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-server"
-version = "0.0.6-alpha"
+version = "0.0.8-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb12c0cb502dd2998fb3560e3999f58ac819719fd6513763029608dcf77f4a88"
+checksum = "1cda36e498d8b8d32fda399807b58c68f939a54777c104287840264725338ce9"
 dependencies = [
  "anstyle",
  "base64 0.22.1",
@@ -6342,7 +6306,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6380,7 +6344,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6406,7 +6370,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -6890,9 +6854,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
@@ -7251,7 +7215,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7385,40 +7349,60 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.1.3-beta"
+version = "0.1.5-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f5c8ae702c58cd1a127fe5785db014ddba783e18c87ad936275bb6e4023a13"
+checksum = "3f994c9c78cd32bdf4fe814f73deb46346a2e3d8b0258a9cc6349f7cffea9532"
 dependencies = [
  "base64 0.22.1",
+ "futures",
  "influxive-otel-atomic-obs",
  "serde",
+ "slab",
  "tokio",
  "tracing",
  "tx5-connection",
- "tx5-core",
+ "tx5-core 0.1.5-beta",
  "url",
 ]
 
 [[package]]
 name = "tx5-connection"
-version = "0.1.3-beta"
+version = "0.1.5-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f97d4960fe1d84c6cf6335df355841a43377feb57df4b4996e24d0f50e07774"
+checksum = "c768f3c4e732c8f4e5ac8c458eb638c9ee4d5cec9a079aaae3b14bc625027ada"
 dependencies = [
  "bit_field",
  "futures",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
- "tx5-core",
+ "tx5-core 0.1.5-beta",
  "tx5-go-pion",
  "tx5-signal",
 ]
 
 [[package]]
 name = "tx5-core"
-version = "0.1.3-beta"
+version = "0.0.16-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52d9b50b494b1d92b6a12ab9d3f98d420d549e85b128f671abfb67c1cf8cba"
+checksum = "140653788727a8aa2b4bd4d0af87cdc374956104c27aa092c5c965a11db39073"
+dependencies = [
+ "base64 0.13.1",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "tx5-core"
+version = "0.1.5-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa653b3dc7b127c29fca5bd9ba70a31afa1c9df3c796f35efca576b10c2aaa13"
 dependencies = [
  "app_dirs2",
  "base64 0.22.1",
@@ -7435,9 +7419,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.1.3-beta"
+version = "0.1.5-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450fffbc9207428bd387e319aa88fe226cad0950937e773f9bbf0672c6d0104e"
+checksum = "a930b75b6baf3bae2090e44fe9ff4566f7ae4d979e6794f82ce0207b2fed7a82"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -7449,9 +7433,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.1.3-beta"
+version = "0.1.5-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23094d66b8570e86418520c9317fe8d16c0b45ed3156bb01b5e14ed674136da9"
+checksum = "b9d40c7d4bec6f9ca0f379981a99ec8765f01e7812a4dc0a27c021cb988c89a5"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -7462,15 +7446,15 @@ dependencies = [
  "ouroboros",
  "sha2",
  "tracing",
- "tx5-core",
+ "tx5-core 0.1.5-beta",
  "zip 0.6.6",
 ]
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.1.3-beta"
+version = "0.1.5-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2acad1aec5d8b8272e1e6c3ddcf4f154163a59429d9c58124b025b53d8c914"
+checksum = "80a2648d5eaa7bc0feb2a90be2b84b148d1ae2a254d568f77d3cc41005648f03"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -7480,21 +7464,42 @@ dependencies = [
  "sha2",
  "tokio",
  "tracing",
- "tx5-core",
+ "tx5-core 0.1.5-beta",
  "zip 0.6.6",
 ]
 
 [[package]]
 name = "tx5-signal"
-version = "0.1.3-beta"
+version = "0.1.5-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67250845c61754644c82d76e5644cfdb21226f6c036ff7aa8d159db411e2b6"
+checksum = "c4d507c5cd6e14fd81cc6d2a6571b1eba35eeda7c11cc00ac56ed7d109cd1265"
 dependencies = [
  "rand 0.8.5",
  "sbd-e2e-crypto-client",
  "tokio",
  "tracing",
- "tx5-core",
+ "tx5-core 0.1.5-beta",
+]
+
+[[package]]
+name = "tx5-signal-srv"
+version = "0.0.16-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129782eaa5ab5445b02776307f38a6eebe4a3de41c3821330ba7de9fc19195bc"
+dependencies = [
+ "clap 4.5.21",
+ "dirs",
+ "futures",
+ "if-addrs 0.10.2",
+ "once_cell",
+ "prometheus",
+ "rand 0.8.5",
+ "sodoken 0.0.11",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tx5-core 0.0.16-alpha",
+ "warp",
 ]
 
 [[package]]
@@ -7944,7 +7949,7 @@ dependencies = [
  "ciborium",
  "derive_builder 0.12.0",
  "hex",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "schemars",
  "semver",
  "serde",
@@ -8034,7 +8039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags 2.6.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "semver",
 ]
 
@@ -8151,7 +8156,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8680,7 +8685,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 members = ["fixture/zomes/foo"]
 
 [workspace.dependencies]
-holochain_zome_types = "0.5.0-dev.0"
+holochain_zome_types = "0.5.0-dev.7"
 
 [dependencies]
 again = "0.1"
@@ -31,9 +31,9 @@ async-trait = "0.1"
 parking_lot = "0.12.1"
 
 holo_hash = { version = "0.5.0-dev.0", features = ["encoding"] }
-holochain_conductor_api = "0.5.0-dev.0"
-holochain_websocket = "0.5.0-dev.0"
-holochain_types = "0.5.0-dev.0"
+holochain_conductor_api = "0.5.0-dev.7"
+holochain_websocket = "0.5.0-dev.7"
+holochain_types = "0.5.0-dev.7"
 holochain_nonce = "0.5.0-dev.0"
 holochain_zome_types = { workspace = true }
 
@@ -44,7 +44,7 @@ tokio = { version = "1.36", features = ["rt"] }
 
 [dev-dependencies]
 fixt = "0.5.0-dev.0"
-holochain = { version = "0.5.0-dev.0", features = ["test_utils"] }
+holochain = { version = "0.5.0-dev.7", features = ["test_utils"] }
 
 [features]
 default = ["lair_signing"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use error::{ConductorApiError, ConductorApiResult};
 pub use holochain_conductor_api::{
     AdminRequest, AdminResponse, AppAuthenticationRequest, AppAuthenticationToken,
     AppAuthenticationTokenIssued, AppInfo, AppRequest, AppResponse, AppStatusFilter,
-    IssueAppAuthenticationTokenPayload, ZomeCall,
+    IssueAppAuthenticationTokenPayload,
 };
 pub use holochain_types::{
     app::{InstallAppPayload, InstalledAppId},

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use holo_hash::AgentPubKey;
-use holochain_conductor_api::ZomeCall;
+use holochain_conductor_api::ZomeCallParamsSigned;
 use holochain_zome_types::{
-    capability::CapSecret, cell::CellId, dependencies::holochain_integrity_types::Signature,
-    zome_io::ZomeCallUnsigned,
+    capability::CapSecret,
+    cell::CellId,
+    dependencies::holochain_integrity_types::Signature,
+    zome_io::{ExternIO, ZomeCallParams},
 };
 
 pub(crate) mod client_signing;
@@ -32,28 +34,17 @@ pub trait AgentSigner {
 
 /// Signs an unsigned zome call using the provided signing implementation
 pub(crate) async fn sign_zome_call(
-    zome_call_unsigned: ZomeCallUnsigned,
+    params: ZomeCallParams,
     signer: Arc<dyn AgentSigner + Send + Sync>,
-) -> Result<ZomeCall> {
-    let pub_key = zome_call_unsigned.provenance.clone();
-
-    let data_to_sign = zome_call_unsigned.data_to_sign().map_err(|e| {
-        anyhow::anyhow!("Failed to get data to sign from unsigned zome call: {}", e)
-    })?;
-
+) -> Result<ZomeCallParamsSigned> {
+    let pub_key = params.provenance.clone();
+    let (bytes, bytes_hash) = params.serialize_and_hash()?;
     let signature = signer
-        .sign(&zome_call_unsigned.cell_id, pub_key, data_to_sign)
+        .sign(&params.cell_id, pub_key, bytes_hash.into())
         .await?;
 
-    Ok(ZomeCall {
-        cell_id: zome_call_unsigned.cell_id,
-        zome_name: zome_call_unsigned.zome_name,
-        fn_name: zome_call_unsigned.fn_name,
-        payload: zome_call_unsigned.payload,
-        cap_secret: zome_call_unsigned.cap_secret,
-        provenance: zome_call_unsigned.provenance,
-        nonce: zome_call_unsigned.nonce,
-        expires_at: zome_call_unsigned.expires_at,
+    Ok(ZomeCallParamsSigned {
+        bytes: ExternIO(bytes),
         signature,
     })
 }

--- a/tests/admin.rs
+++ b/tests/admin.rs
@@ -10,7 +10,7 @@ use holochain_zome_types::prelude::ExternIO;
 use kitsune_p2p_types::fixt::AgentInfoSignedFixturator;
 use std::collections::BTreeSet;
 use std::net::Ipv4Addr;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 const ROLE_NAME: &str = "foo";
 
@@ -45,9 +45,8 @@ async fn signed_zome_call() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -122,9 +121,8 @@ async fn storage_info() {
         .install_app(InstallAppPayload {
             agent_key: Some(agent_key.clone()),
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -158,9 +156,8 @@ async fn dump_network_stats() {
         .install_app(InstallAppPayload {
             agent_key: Some(agent_key.clone()),
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -171,7 +168,7 @@ async fn dump_network_stats() {
 
     let network_stats = admin_ws.dump_network_stats().await.unwrap();
 
-    assert!(network_stats.contains("\"backend\": \"tx2-quic\""));
+    assert!(network_stats.contains("\"backend\": \"backendMem\""));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -187,9 +184,8 @@ async fn get_compatible_cells() {
         .install_app(InstallAppPayload {
             agent_key: Some(agent_key.clone()),
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -232,9 +228,8 @@ async fn revoke_agent_key() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: None,
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -277,8 +272,7 @@ async fn agent_info() {
         .install_app(InstallAppPayload {
             agent_key: Some(agent_key.clone()),
             installed_app_id: Some(app_id.clone()),
-            existing_cells: HashMap::new(),
-            membrane_proofs: Some(HashMap::new()),
+            roles_settings: None,
             network_seed: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
@@ -289,8 +283,7 @@ async fn agent_info() {
     admin_ws.enable_app(app_id.clone()).await.unwrap();
 
     let agent_infos = admin_ws.agent_info(None).await.unwrap();
-    // 2 agent infos expected, 1 app agent and 1 DPKI agent.
-    assert_eq!(agent_infos.len(), 2);
+    assert_eq!(agent_infos.len(), 1);
 
     let other_agent = fixt::fixt!(AgentInfoSigned);
     admin_ws
@@ -299,7 +292,7 @@ async fn agent_info() {
         .unwrap();
 
     let agent_infos = admin_ws.agent_info(None).await.unwrap();
-    assert_eq!(agent_infos.len(), 3);
+    assert_eq!(agent_infos.len(), 2);
     assert!(agent_infos.contains(&other_agent));
 }
 
@@ -316,8 +309,7 @@ async fn list_cell_ids() {
         .install_app(InstallAppPayload {
             agent_key: Some(agent_key),
             installed_app_id: Some(app_id.clone()),
-            existing_cells: HashMap::new(),
-            membrane_proofs: Some(HashMap::new()),
+            roles_settings: None,
             network_seed: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -38,9 +38,8 @@ async fn network_info() {
         .install_app(InstallAppPayload {
             agent_key: Some(agent_key.clone()),
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -113,9 +112,8 @@ async fn handle_signal() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -211,9 +209,8 @@ async fn close_on_drop_is_clone_safe() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -280,9 +277,8 @@ async fn deferred_memproof_installation() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Bundle(app_bundle_deferred_memproofs),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,

--- a/tests/clone_cell.rs
+++ b/tests/clone_cell.rs
@@ -1,5 +1,5 @@
 use std::net::Ipv4Addr;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use holochain::{
     prelude::{DeleteCloneCellPayload, DisableCloneCellPayload, EnableCloneCellPayload},
@@ -32,9 +32,8 @@ async fn clone_cell_management() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,
@@ -185,9 +184,8 @@ pub async fn app_info_refresh() {
         .install_app(InstallAppPayload {
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
-            membrane_proofs: None,
             network_seed: None,
-            existing_cells: HashMap::new(),
+            roles_settings: None,
             source: AppBundleSource::Path(PathBuf::from("./fixture/test.happ")),
             ignore_genesis_failure: false,
             allow_throwaway_random_agent_key: false,


### PR DESCRIPTION
The Zome parameters and signing of them has been changed. This change uses the new, more flexible approach.

Closes #127 