### PR TITLE
feat: Improve connection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 ### Added
+- New `connect_with_request_and_config` to expose the raw websocket connection parameters. This allows for more control
+  over the connection setup, such as setting custom headers.
+- The `connect_with_config` that already existed for the admin websocket now has an equivalent for the app websocket.
+  This is useful if you want to change the timeout or other parameters of the websocket connection.
+- A typedef `DynAgentSigner` for `Arc<dyn AgentSigner + Send + Sync>` which makes the type more convenient to use.
+- Exported more common types so that uses are less likely to need to import other libraries, these are `AllowedOrigins`
+  and `ConnectRequest`. 
 ### Changed
+- It was possible to pass multiple socket addresses to the `connect` method of the `AppWebsocket` and `AdminWebsocket`.
+  This allows you to try multiple addresses and connect to the first one that works. This wasn't working because the 
+  client was just taking the first valid address and retrying connecting to that. Now the client will try each valid 
+  address, once, in turn.
 ### Fixed
 ### Removed
+- Remove `again::retry` from client connect calls. It was preventing the client from trying all available addresses. 
+  If you need retry logic, please implement it in your application
 
 ## 2025-02-27: v0.7.0-dev.2
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,17 +45,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "again"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05802a5ad4d172eaf796f7047b42d0af9db513585d16d4169660a21613d34b93"
-dependencies = [
- "log",
- "rand 0.7.3",
- "wasm-timer",
-]
-
-[[package]]
 name = "ahash"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,7 +2517,6 @@ dependencies = [
 name = "holochain_client"
 version = "0.7.0-dev.2"
 dependencies = [
- "again",
  "anyhow",
  "async-trait",
  "ed25519-dalek",
@@ -7980,21 +7968,6 @@ checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ members = ["fixture/zomes/foo"]
 holochain_zome_types = "0.5.0-dev.7"
 
 [dependencies]
-again = "0.1"
 anyhow = "1.0"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 serde = "1.0.193"

--- a/src/admin_websocket.rs
+++ b/src/admin_websocket.rs
@@ -77,7 +77,7 @@ impl AdminWebsocket {
     /// use std::time::Duration;
     /// use holochain_client::{AdminWebsocket, AllowedOrigins, WebsocketConfig};
     ///
-    /// // Create a client config from the default and sets a timeout that is lower than the default
+    /// // Create a client config from the default and set a timeout that is lower than the default
     /// let mut client_config = WebsocketConfig::CLIENT_DEFAULT;
     /// client_config.default_request_timeout = Duration::from_secs(10);
     ///

--- a/src/admin_websocket.rs
+++ b/src/admin_websocket.rs
@@ -109,7 +109,7 @@ impl AdminWebsocket {
         }))
     }
 
-    /// Connect to a Conductor API admin websocket with a custom [ConnectRequest] and [AdminWebsocket].
+    /// Connect to a Conductor API admin websocket with a custom [ConnectRequest] and [WebsocketConfig].
     ///
     /// This is a low-level constructor that allows you to pass a custom [ConnectRequest] to the
     /// websocket connection. You should use this if you need to set custom connection headers.

--- a/src/admin_websocket.rs
+++ b/src/admin_websocket.rs
@@ -11,7 +11,7 @@ use holochain_types::{
     dna::AgentPubKey,
     prelude::{CellId, DeleteCloneCellPayload, InstallAppPayload, UpdateCoordinatorsPayload},
 };
-use holochain_websocket::{connect, WebsocketConfig, WebsocketSender};
+use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use holochain_zome_types::{
     capability::GrantedFunctions,
     prelude::{DnaDef, GrantZomeCallCapabilityPayload, Record},
@@ -20,6 +20,7 @@ use kitsune_p2p_types::agent_info::AgentInfoSigned;
 use serde::{Deserialize, Serialize};
 use std::{net::ToSocketAddrs, sync::Arc};
 
+/// A websocket connection to the Holochain Conductor admin interface.
 #[derive(Clone)]
 pub struct AdminWebsocket {
     tx: WebsocketSender,
@@ -39,39 +40,122 @@ pub struct AuthorizeSigningCredentialsPayload {
 }
 
 impl AdminWebsocket {
-    /// Connect to a Conductor API AdminWebsocket.
+    /// Connect to a Conductor API admin websocket.
     ///
-    /// `socket_addr` is a websocket address that implements `ToSocketAddr`.
-    /// See trait [`ToSocketAddr`](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html#tymethod.to_socket_addrs).
+    /// `socket_addr` is a websocket address that implements [ToSocketAddr](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html#tymethod.to_socket_addrs).
     ///
     /// # Examples
     ///
     /// ```rust,no_run
     /// # #[tokio::main]
-    /// # async fn main() -> anyhow::Result<()> {
+    /// # async fn main() {
     /// use std::net::Ipv4Addr;
-    /// let admin_ws = holochain_client::AdminWebsocket::connect((Ipv4Addr::LOCALHOST, 30_000)).await?;
-    /// # Ok(())
+    /// use holochain_client::AdminWebsocket;
+    ///
+    /// let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, 30_000)).await.unwrap();
     /// # }
     /// ```
     ///
-    /// As string `"localhost:30000"`
-    /// As tuple `([127.0.0.1], 30000)`
+    /// As string: `"localhost:30000"`
+    ///
+    /// As tuple: `([127.0.0.1], 30000)`
     pub async fn connect(socket_addr: impl ToSocketAddrs) -> ConductorApiResult<Self> {
         Self::connect_with_config(socket_addr, Arc::new(WebsocketConfig::CLIENT_DEFAULT)).await
     }
 
-    /// Connect to a Conductor API AdminWebsocket with a custom WebsocketConfig.
+    /// Connect to a Conductor API admin websocket with a custom [WebsocketConfig].
+    ///
+    /// You need to use this constructor if you want to set a lower timeout than the default.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use std::net::Ipv4Addr;
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use holochain_client::{AdminWebsocket, AllowedOrigins, WebsocketConfig};
+    ///
+    /// // Create a client config from the default and sets a timeout that is lower than the default
+    /// let mut client_config = WebsocketConfig::CLIENT_DEFAULT;
+    /// client_config.default_request_timeout = Duration::from_secs(10);
+    ///
+    /// let client_config = Arc::new(client_config);
+    ///
+    /// let admin_ws = AdminWebsocket::connect_with_config((Ipv4Addr::LOCALHOST, 30_000), client_config).await.unwrap();
+    /// # }
+    /// ```
     pub async fn connect_with_config(
         socket_addr: impl ToSocketAddrs,
         websocket_config: Arc<WebsocketConfig>,
     ) -> ConductorApiResult<Self> {
-        let addr = socket_addr
-            .to_socket_addrs()?
-            .next()
-            .expect("invalid websocket address");
+        let mut last_err = None;
+        for addr in socket_addr.to_socket_addrs()? {
+            let request: ConnectRequest = addr.into();
 
-        let (tx, mut rx) = again::retry(|| connect(websocket_config.clone(), addr)).await?;
+            match Self::connect_with_request_and_config(request, websocket_config.clone()).await {
+                Ok(admin_ws) => return Ok(admin_ws),
+                Err(e) => {
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            ConductorApiError::WebsocketError(holochain_websocket::WebsocketError::Other(
+                "No addresses resolved".to_string(),
+            ))
+        }))
+    }
+
+    /// Connect to a Conductor API admin websocket with a custom [ConnectRequest] and [AdminWebsocket].
+    ///
+    /// This is a low-level constructor that allows you to pass a custom [ConnectRequest] to the
+    /// websocket connection. You should use this if you need to set custom connection headers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use holochain_client::{AdminWebsocket, AllowedOrigins, WebsocketConfig, ConnectRequest};
+    ///
+    /// // Use the default client config
+    /// let mut client_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
+    ///
+    /// // Attempt to connect to Holochain on one of these interfaces on port 30,000
+    /// let connect_to = vec![
+    ///     SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 30_000),
+    ///     SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 30_000),
+    /// ];
+    /// for addr in connect_to {
+    ///     // Send a request with a custom origin header to identify the client
+    ///     let mut request: ConnectRequest = addr.into();
+    ///     let request = request
+    ///         .try_set_header("Origin", "my_cli_app")
+    ///         .unwrap();
+    ///
+    ///     match AdminWebsocket::connect_with_request_and_config(request, client_config.clone()).await {
+    ///         Ok(admin_ws) => {
+    ///             println!("Connected to {:?}", addr);
+    ///             break;
+    ///         }
+    ///         Err(e) => {
+    ///             eprintln!("Failed to connect to {:?}: {}", addr, e);
+    ///         }
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    pub async fn connect_with_request_and_config(
+        request: ConnectRequest,
+        websocket_config: Arc<WebsocketConfig>,
+    ) -> ConductorApiResult<Self> {
+        let (tx, mut rx) = connect(websocket_config.clone(), request).await?;
 
         // WebsocketReceiver needs to be polled in order to receive responses
         // from remote to sender requests.
@@ -86,7 +170,7 @@ impl AdminWebsocket {
 
     /// Issue an app authentication token for the specified app.
     ///
-    /// A token is required to create an [AppAgentWebsocket] connection.
+    /// A token is required to create an [AppWebsocket](crate::AppWebsocket) connection.
     pub async fn issue_app_auth_token(
         &self,
         payload: IssueAppAuthenticationTokenPayload,

--- a/src/app_websocket.rs
+++ b/src/app_websocket.rs
@@ -1,8 +1,6 @@
 use crate::app_websocket_inner::AppWebsocketInner;
-use crate::{
-    signing::{sign_zome_call, AgentSigner},
-    ConductorApiError, ConductorApiResult,
-};
+use crate::signing::DynAgentSigner;
+use crate::{signing::sign_zome_call, ConductorApiError, ConductorApiResult};
 use anyhow::{anyhow, Result};
 use holo_hash::AgentPubKey;
 use holochain_conductor_api::{
@@ -15,6 +13,7 @@ use holochain_types::app::{
     NetworkInfoRequestPayload,
 };
 use holochain_types::prelude::{CloneId, Signal};
+use holochain_websocket::{ConnectRequest, WebsocketConfig};
 use holochain_zome_types::{
     clone::ClonedCell,
     prelude::{CellId, ExternIO, FunctionName, RoleName, Timestamp, ZomeCallParams, ZomeName},
@@ -22,51 +21,165 @@ use holochain_zome_types::{
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
+/// A websocket connection to a Holochain app running in a Conductor.
 #[derive(Clone)]
 pub struct AppWebsocket {
     pub my_pub_key: AgentPubKey,
     inner: AppWebsocketInner,
     app_info: AppInfo,
-    signer: Arc<dyn AgentSigner + Send + Sync>,
+    signer: DynAgentSigner,
 }
 
 impl AppWebsocket {
-    /// Connect to a Conductor API AppWebsocket with a specific app id.
+    /// Connect to a Conductor API app websocket.
     ///
-    /// `socket_addr` is a websocket address that implements `ToSocketAddr`.
-    /// See trait [`ToSocketAddr`](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html#tymethod.to_socket_addrs).
+    /// `socket_addr` is a websocket address that implements [ToSocketAddr](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html#tymethod.to_socket_addrs).
+    ///
+    /// `token` is an [AppAuthenticationToken] that is issued by the admin interface using [issue_app_auth_token](crate::AdminWebsocket::issue_app_auth_token).
+    /// Tokens are issued for a specific installed app, so this websocket will only be able to interact with that app.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
     /// # #[tokio::main]
-    /// # async fn main() -> anyhow::Result<()> {
+    /// # async fn main() {
     /// use std::net::Ipv4Addr;
-    /// let mut admin_ws = holochain_client::AdminWebsocket::connect((Ipv4Addr::LOCALHOST, 30_000)).await?;
+    /// use holochain_client::{AdminWebsocket, AppWebsocket, ClientAgentSigner};
+    ///
+    /// let mut admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, 30_000)).await.unwrap();
     ///
     /// let app_id = "test-app".to_string();
-    /// let issued = admin_ws.issue_app_auth_token(app_id.clone().into()).await?;
-    /// let signer = holochain_client::ClientAgentSigner::default();
-    /// let app_ws = holochain_client::AppWebsocket::connect((Ipv4Addr::LOCALHOST, 30_001), issued.token, signer.into()).await?;
-    /// # Ok(())
+    /// let issued = admin_ws.issue_app_auth_token(app_id.clone().into()).await.unwrap();
+    /// let signer = ClientAgentSigner::default();
+    /// let app_ws = AppWebsocket::connect((Ipv4Addr::LOCALHOST, 30_001), issued.token, signer.into()).await.unwrap();
     /// # }
     /// ```
     ///
-    /// As string `"localhost:30000"`
-    /// As tuple `([127.0.0.1], 30000)`
+    /// As string: `"localhost:30000"`
+    ///
+    /// As tuple: `([127.0.0.1], 30000)`
     pub async fn connect(
         socket_addr: impl ToSocketAddrs,
         token: AppAuthenticationToken,
-        signer: Arc<dyn AgentSigner + Send + Sync>,
+        signer: DynAgentSigner,
     ) -> Result<Self> {
         let app_ws = AppWebsocketInner::connect(socket_addr).await?;
+        Self::post_connect(app_ws, token, signer).await
+    }
 
-        app_ws
+    /// Connect to a Conductor API app websocket with a custom [WebsocketConfig].
+    ///
+    /// You need to use this constructor if you want to set a lower timeout than the default.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use std::net::Ipv4Addr;
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use holochain_client::{AdminWebsocket, AppWebsocket, AllowedOrigins, WebsocketConfig, ClientAgentSigner};
+    ///
+    /// let mut admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, 30_000)).await.unwrap();
+    ///
+    /// let app_id = "test-app".to_string();
+    /// let issued = admin_ws.issue_app_auth_token(app_id.clone().into()).await.unwrap();
+    ///
+    /// // Create a client config from the default and sets a timeout that is lower than the default
+    /// let mut client_config = WebsocketConfig::CLIENT_DEFAULT;
+    /// client_config.default_request_timeout = Duration::from_secs(10);
+    ///
+    /// let client_config = Arc::new(client_config);
+    ///
+    /// let signer = ClientAgentSigner::default();
+    /// let app_ws = AppWebsocket::connect_with_config((Ipv4Addr::LOCALHOST, 30_001), client_config, issued.token, signer.into()).await.unwrap();
+    /// # }
+    /// ```
+    pub async fn connect_with_config(
+        socket_addr: impl ToSocketAddrs,
+        websocket_config: Arc<WebsocketConfig>,
+        token: AppAuthenticationToken,
+        signer: DynAgentSigner,
+    ) -> Result<Self> {
+        let app_ws = AppWebsocketInner::connect_with_config(socket_addr, websocket_config).await?;
+        Self::post_connect(app_ws, token, signer).await
+    }
+
+    /// Connect to a Conductor API app websocket with a custom [WebsocketConfig] and [ConnectRequest].
+    ///
+    /// This is a low-level constructor that allows you to pass a custom [ConnectRequest] to the
+    /// websocket connection. You should use this if you need to set custom connection headers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    /// use holochain_client::{
+    ///     AdminWebsocket, AppWebsocket, AllowedOrigins, WebsocketConfig,
+    ///     ConnectRequest, ClientAgentSigner, AgentSigner, DynAgentSigner
+    /// };
+    ///
+    /// let mut admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, 30_000)).await.unwrap();
+    ///
+    /// let app_id = "test-app".to_string();
+    /// let issued = admin_ws.issue_app_auth_token(app_id.clone().into()).await.unwrap();
+    ///
+    /// // Use the default client config
+    /// let mut client_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
+    ///
+    /// let signer: DynAgentSigner = ClientAgentSigner::default().into();
+    ///
+    /// // Attempt to connect to Holochain on one of these interfaces on port 30,001
+    /// let connect_to = vec![
+    ///     SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 30_001),
+    ///     SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 30_001),
+    /// ];
+    /// for addr in connect_to {
+    ///     // Send a request with a custom origin header to identify the client
+    ///     let mut request: ConnectRequest = addr.into();
+    ///     let request = request
+    ///         .try_set_header("Origin", "my_cli_app")
+    ///         .unwrap();
+    ///
+    ///     match AppWebsocket::connect_with_request_and_config(request, client_config.clone(), issued.token.clone(), signer.clone()).await {
+    ///         Ok(admin_ws) => {
+    ///             println!("Connected to {:?}", addr);
+    ///             break;
+    ///         }
+    ///         Err(e) => {
+    ///             eprintln!("Failed to connect to {:?}: {}", addr, e);
+    ///         }
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    pub async fn connect_with_request_and_config(
+        request: ConnectRequest,
+        websocket_config: Arc<WebsocketConfig>,
+        token: AppAuthenticationToken,
+        signer: DynAgentSigner,
+    ) -> Result<Self> {
+        let app_ws =
+            AppWebsocketInner::connect_with_config_and_request(websocket_config, request).await?;
+        Self::post_connect(app_ws, token, signer).await
+    }
+
+    async fn post_connect(
+        inner: AppWebsocketInner,
+        token: AppAuthenticationToken,
+        signer: DynAgentSigner,
+    ) -> Result<Self> {
+        inner
             .authenticate(token)
             .await
             .map_err(|err| anyhow!("Failed to send authentication: {err:?}"))?;
 
-        let app_info = app_ws
+        let app_info = inner
             .app_info()
             .await
             .map_err(|err| anyhow!("Error fetching app_info {err:?}"))?
@@ -74,7 +187,7 @@ impl AppWebsocket {
 
         Ok(AppWebsocket {
             my_pub_key: app_info.agent_pub_key.clone(),
-            inner: app_ws,
+            inner,
             app_info,
             signer,
         })

--- a/src/app_websocket_inner.rs
+++ b/src/app_websocket_inner.rs
@@ -35,7 +35,7 @@ impl AppWebsocketInner {
             let request: ConnectRequest = addr.into();
 
             match Self::connect_with_config_and_request(websocket_config.clone(), request).await {
-                Ok(admin_ws) => return Ok(admin_ws),
+                Ok(app_ws) => return Ok(app_ws),
                 Err(e) => {
                     last_err = Some(e);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,10 @@ pub use holochain_conductor_api::{
 pub use holochain_types::{
     app::{InstallAppPayload, InstalledAppId},
     dna::AgentPubKey,
+    websocket::AllowedOrigins,
 };
-pub use holochain_websocket::WebsocketConfig;
+pub use holochain_websocket::{ConnectRequest, WebsocketConfig};
 pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]
 pub use signing::lair_signing::LairAgentSigner;
-pub use signing::AgentSigner;
+pub use signing::{AgentSigner, DynAgentSigner};

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -16,6 +16,8 @@ pub(crate) mod client_signing;
 #[cfg(feature = "lair_signing")]
 pub(crate) mod lair_signing;
 
+pub type DynAgentSigner = Arc<dyn AgentSigner + Send + Sync>;
+
 #[async_trait]
 pub trait AgentSigner {
     /// Sign the given data with the public key found in the agent id of the provenance.
@@ -35,7 +37,7 @@ pub trait AgentSigner {
 /// Signs an unsigned zome call using the provided signing implementation
 pub(crate) async fn sign_zome_call(
     params: ZomeCallParams,
-    signer: Arc<dyn AgentSigner + Send + Sync>,
+    signer: DynAgentSigner,
 ) -> Result<ZomeCallParamsSigned> {
     let pub_key = params.provenance.clone();
     let (bytes, bytes_hash) = params.serialize_and_hash()?;

--- a/src/signing/client_signing.rs
+++ b/src/signing/client_signing.rs
@@ -1,4 +1,4 @@
-use super::AgentSigner;
+use super::{AgentSigner, DynAgentSigner};
 use async_trait::async_trait;
 use ed25519_dalek::Signer;
 use holo_hash::AgentPubKey;
@@ -69,7 +69,7 @@ impl AgentSigner for ClientAgentSigner {
 }
 
 /// Convert the ClientAgentSigner into an `Arc<Box<dyn AgentSigner + Send + Sync>>`
-impl From<ClientAgentSigner> for Arc<dyn AgentSigner + Send + Sync> {
+impl From<ClientAgentSigner> for DynAgentSigner {
     fn from(cas: ClientAgentSigner) -> Self {
         Arc::new(cas)
     }

--- a/tests/admin.rs
+++ b/tests/admin.rs
@@ -10,7 +10,7 @@ use holochain_types::websocket::AllowedOrigins;
 use holochain_zome_types::prelude::ExternIO;
 use kitsune_p2p_types::fixt::AgentInfoSignedFixturator;
 use std::collections::BTreeSet;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::{collections::HashMap, path::PathBuf};
 
 const ROLE_NAME: &str = "foo";
@@ -403,4 +403,25 @@ async fn install_app_with_roles_settings() {
         Some(custom_quantum_time)
     );
     assert_eq!(app_role.dna.modifiers.properties, Some(custom_properties));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_multiple_addresses() {
+    let conductor = SweetConductor::from_standard_config().await;
+    let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
+
+    let admin_ws = AdminWebsocket::connect(
+        &[
+            // Shouldn't be able to connect on this port
+            SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 5000),
+            // Should then move on and try this one
+            SocketAddr::new(Ipv4Addr::LOCALHOST.into(), admin_port),
+        ][..],
+    )
+    .await
+    .unwrap();
+
+    // Just to check we are connected and can get a response.
+    let apps = admin_ws.list_apps(None).await.unwrap();
+    assert!(apps.is_empty());
 }


### PR DESCRIPTION
Makes the connect methods consistent between the app and admin websockets. Also exposes the actual parameters to the `connect` function so that callers are free to configure the connection exactly as they want.

That last part, where we expose the `ConnectRequest` I want to back port to 0.4. The rest of this is too much change for 0.4.