### PR TITLE
Impl `Debug` for websocket types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 ### Added
+- Debug implementations for `AppWebsocket` and `AdminWebsocket`.
 - New `connect_with_request_and_config` to expose the raw websocket connection parameters. This allows for more control
   over the connection setup, such as setting custom headers.
 - The `connect_with_config` that already existed for the admin websocket now has an equivalent for the app websocket.

--- a/src/admin_websocket.rs
+++ b/src/admin_websocket.rs
@@ -18,6 +18,7 @@ use holochain_zome_types::{
 };
 use kitsune_p2p_types::agent_info::AgentInfoSigned;
 use serde::{Deserialize, Serialize};
+use std::fmt::Formatter;
 use std::{net::ToSocketAddrs, sync::Arc};
 
 /// A websocket connection to the Holochain Conductor admin interface.
@@ -25,6 +26,12 @@ use std::{net::ToSocketAddrs, sync::Arc};
 pub struct AdminWebsocket {
     tx: WebsocketSender,
     _poll_handle: Arc<AbortOnDropHandle>,
+}
+
+impl std::fmt::Debug for AdminWebsocket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdminWebsocket").finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/app_websocket.rs
+++ b/src/app_websocket.rs
@@ -18,6 +18,7 @@ use holochain_zome_types::{
     clone::ClonedCell,
     prelude::{CellId, ExternIO, FunctionName, RoleName, Timestamp, ZomeCallParams, ZomeName},
 };
+use std::fmt::Formatter;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
@@ -28,6 +29,16 @@ pub struct AppWebsocket {
     inner: AppWebsocketInner,
     app_info: AppInfo,
     signer: DynAgentSigner,
+}
+
+impl std::fmt::Debug for AppWebsocket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppWebsocket")
+            .field("my_pub_key", &self.my_pub_key)
+            .field("inner", &self.inner)
+            .field("app_info", &self.app_info)
+            .finish()
+    }
 }
 
 impl AppWebsocket {

--- a/src/app_websocket_inner.rs
+++ b/src/app_websocket_inner.rs
@@ -6,6 +6,7 @@ use holochain_conductor_api::{
 };
 use holochain_types::signal::Signal;
 use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
+use std::fmt::Formatter;
 use std::{net::ToSocketAddrs, sync::Arc};
 use tokio::sync::Mutex;
 
@@ -15,6 +16,12 @@ pub(crate) struct AppWebsocketInner {
     tx: WebsocketSender,
     event_emitter: Arc<Mutex<EventEmitter>>,
     _abort_handle: Arc<AbortOnDropHandle>,
+}
+
+impl std::fmt::Debug for AppWebsocketInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppWebsocketInner").finish()
+    }
 }
 
 impl AppWebsocketInner {


### PR DESCRIPTION
Adding because it's missing but the HTTP gateway is expected them to be `Debug` so this PR is supporting use over there.