### PR TITLE
fix: Use `ConductorApiResult` instead of `anyhow::Result` for app client connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Exported more common types so that uses are less likely to need to import other libraries, these are `AllowedOrigins`
   and `ConnectRequest`. 
 ### Changed
+- `connect*` methods on the `AppWebsocket` now return a `ConductorApiResult` instead of an `anyhow::Result`. This is 
+  consistent with the `AdminWebsocket`.
 - It was possible to pass multiple socket addresses to the `connect` method of the `AppWebsocket` and `AdminWebsocket`.
   This allows you to try multiple addresses and connect to the first one that works. This wasn't working because the 
   client was just taking the first valid address and retrying connecting to that. Now the client will try each valid 

--- a/src/app_websocket.rs
+++ b/src/app_websocket.rs
@@ -73,7 +73,7 @@ impl AppWebsocket {
         socket_addr: impl ToSocketAddrs,
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
-    ) -> Result<Self> {
+    ) -> ConductorApiResult<Self> {
         let app_ws = AppWebsocketInner::connect(socket_addr).await?;
         Self::post_connect(app_ws, token, signer).await
     }
@@ -112,7 +112,7 @@ impl AppWebsocket {
         websocket_config: Arc<WebsocketConfig>,
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
-    ) -> Result<Self> {
+    ) -> ConductorApiResult<Self> {
         let app_ws = AppWebsocketInner::connect_with_config(socket_addr, websocket_config).await?;
         Self::post_connect(app_ws, token, signer).await
     }
@@ -174,7 +174,7 @@ impl AppWebsocket {
         websocket_config: Arc<WebsocketConfig>,
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
-    ) -> Result<Self> {
+    ) -> ConductorApiResult<Self> {
         let app_ws =
             AppWebsocketInner::connect_with_config_and_request(websocket_config, request).await?;
         Self::post_connect(app_ws, token, signer).await
@@ -184,17 +184,13 @@ impl AppWebsocket {
         inner: AppWebsocketInner,
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
-    ) -> Result<Self> {
-        inner
-            .authenticate(token)
-            .await
-            .map_err(|err| anyhow!("Failed to send authentication: {err:?}"))?;
+    ) -> ConductorApiResult<Self> {
+        inner.authenticate(token).await?;
 
         let app_info = inner
             .app_info()
-            .await
-            .map_err(|err| anyhow!("Error fetching app_info {err:?}"))?
-            .ok_or(anyhow!("App doesn't exist"))?;
+            .await?
+            .ok_or(ConductorApiError::AppNotFound)?;
 
         Ok(AppWebsocket {
             my_pub_key: app_info.agent_pub_key.clone(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,8 @@ pub enum ConductorApiError {
     SignZomeCallError(String),
     #[error("Cell not found")]
     CellNotFound,
+    #[error("App not found")]
+    AppNotFound,
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
 }


### PR DESCRIPTION
This is already the case for the admin client, and anyhow is really fiddly to use with other error handling